### PR TITLE
Fix for IOS: The padding specified in RFC 3548 section 2.2 is not req…

### DIFF
--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -53,6 +53,8 @@ namespace Google.Authenticator
             if (accountTitleNoSpaces == null) { throw new NullReferenceException("Account Title is null"); }
             accountTitleNoSpaces = RemoveWhitespace(accountTitleNoSpaces);
             string encodedSecretKey = Base32Encoding.ToString(accountSecretKey);
+            // The padding specified in RFC 3548 section 2.2 is not required and should be omitted.
+            encodedSecretKey = encodedSecretKey.Replace("=", "");
             string provisionUrl = null;
             if (String.IsNullOrWhiteSpace(issuer))
             {


### PR DESCRIPTION
…uired and should be omitted.

Trailing padding characters should be omitted from the secret in the URL to make the URL in the QR code work for IOS devices. Also see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#secret.

I tested two QR codes, one with and one without trailing '=' signs.
Both worked on my Android device, but on IOS only the one without the trailing padding characters worked.