### PR TITLE
Added override to ValidateTwoFactorPIN that accepts secretKey as Byte[],

### DIFF
--- a/Google.Authenticator.Tests/AuthCodeTest.cs
+++ b/Google.Authenticator.Tests/AuthCodeTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Xunit;
 using Shouldly;
+using System.Text;
 
 namespace Google.Authenticator.Tests
 {
@@ -20,6 +21,26 @@ namespace Google.Authenticator.Tests
             var actual = tfa.GeneratePINAtInterval(secretKey, currentTime, 6);
 
             actual.ShouldBe(expected);   
+        }
+
+        [Fact]
+        public void ValidateTwoFactorPIN_WithByteArray_Succeeds()
+        {
+            // Arrange
+            var secretKeyByteArray = Encoding.UTF8.GetBytes("PJWUMZKAUUFQKJBAMD6VGJ6RULFVW4ZH");
+
+            var tfa = new TwoFactorAuthenticator();
+
+            long currentTime = GetCurrentCounter();
+            var currentCode = tfa.GeneratePINAtInterval(secretKeyByteArray, currentTime, 6);
+
+            // Act/Assert
+            Assert.True(tfa.ValidateTwoFactorPIN(secretKeyByteArray, currentCode));
+        }
+
+        private static long GetCurrentCounter()
+        {
+            return (long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds / 30;
         }
     }
 }


### PR DESCRIPTION
    so any bytes can be used in the secretKey,
    not just bytes that map to valid UTF-8 characters.

    Added unit test