### PR TITLE
Feature/net6 workaround

### DIFF
--- a/.idea/.idea.Google.Authenticator/.idea/misc.xml
+++ b/.idea/.idea.Google.Authenticator/.idea/misc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
-    <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
-  </component>
-</project>

--- a/.idea/.idea.Google.Authenticator/.idea/misc.xml
+++ b/.idea/.idea.Google.Authenticator/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
+    <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
+  </component>
+</project>

--- a/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
+++ b/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452;net5.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Google.Authenticator/Google.Authenticator.csproj
+++ b/Google.Authenticator/Google.Authenticator.csproj
@@ -1,7 +1,7 @@
 ﻿
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net5.0;net6.0</TargetFrameworks>
     <Product>Google Authenticator Two-Factor</Product>
     <Title>Google Authenticator Two-Factor Authentication Library</Title>
     <Description>Google Authenticator Two-Factor Authentication Library (Not officially affiliated with Google.)</Description>
@@ -34,6 +34,9 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5'">
     <DefineConstants>NET5_0;NETCOREAPP</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6'">
+    <DefineConstants>NET6_0;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -81,15 +81,15 @@ namespace Google.Authenticator
             var qrCodeUrl = "";
             try
             {
+                               using (var qrGenerator = new QRCodeGenerator())
+                using (var qrCodeData = qrGenerator.CreateQrCode(provisionUrl, QRCodeGenerator.ECCLevel.Q))
                 #if NET6_0
-                    var qrGenerator = new QRCodeGenerator();
-                    var qrCodeData = qrGenerator.CreateQrCode(provisionUrl, QRCodeGenerator.ECCLevel.Q);
-                    var qrCode = new PngByteQRCode(qrCodeData);
-                    var qrCodeImage = qrCode.GetGraphic(qrPixelsPerModule);
-                    qrCodeUrl = $"data:image/png;base64,{Convert.ToBase64String(qrCodeImage)}";
+                    using (var qrCode = new PngByteQRCode(qrCodeData))
+                    {
+                        var qrCodeImage = qrCode.GetGraphic(qrPixelsPerModule);
+                        qrCodeUrl = $"data:image/png;base64,{Convert.ToBase64String(qrCodeImage)}";
+                    }
                 #else
-                    using (var qrGenerator = new QRCodeGenerator())
-                    using (var qrCodeData = qrGenerator.CreateQrCode(provisionUrl, QRCodeGenerator.ECCLevel.Q))
                     using (var qrCode = new QRCode(qrCodeData))
                     using (var qrCodeImage = qrCode.GetGraphic(qrPixelsPerModule))
                     using (var ms = new MemoryStream())
@@ -98,6 +98,7 @@ namespace Google.Authenticator
                         qrCodeUrl = $"data:image/png;base64,{Convert.ToBase64String(ms.ToArray())}";
                     }
                 #endif
+
             }
             catch (TypeInitializationException e)
             {

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -81,15 +81,23 @@ namespace Google.Authenticator
             var qrCodeUrl = "";
             try
             {
-                using (var qrGenerator = new QRCodeGenerator())
-                using (var qrCodeData = qrGenerator.CreateQrCode(provisionUrl, QRCodeGenerator.ECCLevel.Q))
-                using (var qrCode = new QRCode(qrCodeData))
-                using (var qrCodeImage = qrCode.GetGraphic(qrPixelsPerModule))
-                using (var ms = new MemoryStream())
-                {
-                    qrCodeImage.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-                    qrCodeUrl = $"data:image/png;base64,{Convert.ToBase64String(ms.ToArray())}";
-                }
+                #if NET6_0
+                    var qrGenerator = new QRCodeGenerator();
+                    var qrCodeData = qrGenerator.CreateQrCode(provisionUrl, QRCodeGenerator.ECCLevel.Q);
+                    var qrCode = new PngByteQRCode(qrCodeData);
+                    var qrCodeImage = qrCode.GetGraphic(qrPixelsPerModule);
+                    qrCodeUrl = $"data:image/png;base64,{Convert.ToBase64String(qrCodeImage)}";
+                #else
+                    using (var qrGenerator = new QRCodeGenerator())
+                    using (var qrCodeData = qrGenerator.CreateQrCode(provisionUrl, QRCodeGenerator.ECCLevel.Q))
+                    using (var qrCode = new QRCode(qrCodeData))
+                    using (var qrCodeImage = qrCode.GetGraphic(qrPixelsPerModule))
+                    using (var ms = new MemoryStream())
+                    {
+                        qrCodeImage.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                        qrCodeUrl = $"data:image/png;base64,{Convert.ToBase64String(ms.ToArray())}";
+                    }
+                #endif
             }
             catch (TypeInitializationException e)
             {


### PR DESCRIPTION
It seems the QRCode Class is no longer available in QRCoder for .NET6.
Throws an "Could not load type 'QRCoder.QRCode' from assembly 'QRCoder, Version=1.4.3.0" exception currently.
I needed this library in one of my projects. 
So i decided to publish my workaround to here. Hopefully it is of use to some