### PR TITLE
AzDO to test on multiple OS

### DIFF
--- a/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
+++ b/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX> 
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux> 
     <TargetFrameworks Condition="'$(IsWindows)'=='true'">net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsLinux)'=='true'">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsOSX)'=='true'">netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
+++ b/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452;net5.0;net6.0</TargetFrameworks>
-
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
+    <TargetFrameworks Condition="'$(IsWindows)'=='true'">net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -52,6 +52,7 @@ jobs:
   steps:
   # This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
   - script: dotnet build ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration)
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
     displayName: build package
 
   - script: dotnet pack ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-build --output %Build_ArtifactStagingDirectory%

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -2,12 +2,21 @@ name: BrandonPotter.GoogleAuthenticator - build and test
 trigger: [ master ]
 pr: [ master ]
 
-variables:
-  buildConfiguration: Release
+strategy:
+  matrix:
+    linux:
+      imageName: 'ubuntu-latest'
+    mac:
+      imageName: 'macOS-latest'
+    windows:
+      imageName: 'windows-latest'
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: $(imageName)
 
+variables:
+  buildConfiguration: Release
+ 
 steps:
 
 # There is a legacy project in the solution that dotnet won't build, so restoring and building individual projects
@@ -32,7 +41,7 @@ steps:
 
 # This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
 - script: dotnet pack ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-build --output %Build_ArtifactStagingDirectory%
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')), eq( variables['Agent.OS'], 'Windows_NT' ))
   displayName: pack
 
 - task: PublishBuildArtifacts@1
@@ -40,15 +49,3 @@ steps:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: NugetPackage
 
-# The below will publish the package to Nuget, but requires feed credentials "Nuget" to be created first
-# It also has support for a "develop" branch in case you ever want to use that for pre-releases
-# Alternatively, set up a Release pipeline to publish only when you want to
-
-# - task: NuGetCommand@2
-#   displayName: publish
-#   condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
-#   inputs:
-#     command: push
-#     nuGetFeedType: external
-#     publishFeedCredentials: 'Nuget'
-#     packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -2,50 +2,60 @@ name: BrandonPotter.GoogleAuthenticator - build and test
 trigger: [ master ]
 pr: [ master ]
 
-strategy:
-  matrix:
-    linux:
-      imageName: 'ubuntu-latest'
-    mac:
-      imageName: 'macOS-latest'
-    windows:
-      imageName: 'windows-latest'
+jobs:
+- job: Test
 
-pool:
-  vmImage: $(imageName)
+  strategy:
+    matrix:
+      linux:
+        imageName: 'ubuntu-latest'
+      mac:
+        imageName: 'macOS-latest'
+      windows:
+        imageName: 'windows-latest'
 
-variables:
-  buildConfiguration: Release
- 
-steps:
+  pool:
+    vmImage: $(imageName)
 
-# There is a legacy project in the solution that dotnet won't build, so restoring and building individual projects
-- script: dotnet restore ./Google.Authenticator/Google.Authenticator.csproj 
-  displayName: dotnet restore package
+  variables:
+    buildConfiguration: Release
+  
+  steps:
 
-- script: dotnet restore ./Google.Authenticator.Tests/Google.Authenticator.Tests.csproj --no-dependencies
-  displayName: dotnet restore tests
+  # There is a legacy project in the solution that dotnet won't build, so restoring and building individual projects
+  - script: dotnet restore ./Google.Authenticator/Google.Authenticator.csproj 
+    displayName: dotnet restore package
 
-- script: dotnet build ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-restore
-  displayName: build package
+  - script: dotnet restore ./Google.Authenticator.Tests/Google.Authenticator.Tests.csproj --no-dependencies
+    displayName: dotnet restore tests
 
-- script: dotnet build ./Google.Authenticator.Tests/Google.Authenticator.Tests.csproj --configuration $(buildConfiguration) --no-restore --no-dependencies
-  displayName: build tests
+  - script: dotnet build ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-restore
+    displayName: build package
 
-- task: DotNetCoreCLI@2
-  displayName: test
-  inputs:
-    command: test
-    projects: './Google.Authenticator.Tests/Google.Authenticator.Tests.csproj'
-    arguments: '--configuration $(buildConfiguration)'
+  - script: dotnet build ./Google.Authenticator.Tests/Google.Authenticator.Tests.csproj --configuration $(buildConfiguration) --no-restore --no-dependencies
+    displayName: build tests
 
-# This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
-- script: dotnet pack ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-build --output %Build_ArtifactStagingDirectory%
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')), eq( variables['Agent.OS'], 'Windows_NT' ))
-  displayName: pack
+  - task: DotNetCoreCLI@2
+    displayName: test
+    inputs:
+      command: test
+      projects: './Google.Authenticator.Tests/Google.Authenticator.Tests.csproj'
+      arguments: '--configuration $(buildConfiguration)'
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    artifactName: NugetPackage
+- job: Pack
+  dependsOn: Test
+  condition: succeeded('Test')
+
+  pool:
+    vmImage: 'windows-latest'
+
+  # This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
+  - script: dotnet pack ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-build --output %Build_ArtifactStagingDirectory%
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
+    displayName: pack
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: NugetPackage
 

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -2,6 +2,9 @@ name: BrandonPotter.GoogleAuthenticator - build and test
 trigger: [ master ]
 pr: [ master ]
 
+variables:
+  buildConfiguration: Release
+
 jobs:
 - job: Test
 
@@ -16,9 +19,6 @@ jobs:
 
   pool:
     vmImage: $(imageName)
-
-  variables:
-    buildConfiguration: Release
   
   steps:
 
@@ -50,6 +50,9 @@ jobs:
     vmImage: 'windows-latest'
 
   # This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
+  - script: dotnet build ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration)
+    displayName: build package
+
   - script: dotnet pack ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-build --output %Build_ArtifactStagingDirectory%
     condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
     displayName: pack

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -12,8 +12,8 @@ jobs:
     matrix:
       linux:
         imageName: 'ubuntu-latest'
-      mac:
-        imageName: 'macOS-latest'
+      #mac:
+      #  imageName: 'macOS-latest'
       windows:
         imageName: 'windows-latest'
 

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -49,6 +49,7 @@ jobs:
   pool:
     vmImage: 'windows-latest'
 
+  steps:
   # This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
   - script: dotnet build ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration)
     displayName: build package

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -44,7 +44,7 @@ jobs:
 
 - job: Pack
   dependsOn: Test
-  condition: succeeded('Test')
+  condition: and(succeeded('Test'), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
 
   pool:
     vmImage: 'windows-latest'
@@ -52,11 +52,9 @@ jobs:
   steps:
   # This creates the Nuget package only if the change was from "master". It also supports publishing from a "develop" branch, which is not currently used in this project
   - script: dotnet build ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration)
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
     displayName: build package
 
   - script: dotnet pack ./Google.Authenticator/Google.Authenticator.csproj --configuration $(buildConfiguration) --no-build --output %Build_ArtifactStagingDirectory%
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'),eq(variables['Build.SourceBranchName'], 'develop')))
     displayName: pack
 
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Set up AzDO to test on both Linux and Windows.

(Mac OS can't be added until we remove the explicit net6 reference in the main package).