### PR TITLE
Changed to use EscapeDataString

### DIFF
--- a/Google.Authenticator.Tests/QRCodeTest.cs
+++ b/Google.Authenticator.Tests/QRCodeTest.cs
@@ -11,9 +11,9 @@ namespace Google.Authenticator.Tests
     public class QRCodeTest
     {
         [Theory]
-        [InlineData("issuer", "otpauth://totp/issuer:a@b.com?secret=ONSWG4TFOQ&issuer=issuer")]
-        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a@b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar")]
-        [InlineData("个", "otpauth://totp/%E4%B8%AA:a@b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA")]
+        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer")]
+        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar")]
+        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA")]
         public void CanGenerateQRCode(string issuer, string expectedUrl)
         {
             var subject = new TwoFactorAuthenticator();

--- a/Google.Authenticator/Google.Authenticator.csproj
+++ b/Google.Authenticator/Google.Authenticator.csproj
@@ -7,7 +7,7 @@
     <Description>Google Authenticator Two-Factor Authentication Library (Not officially affiliated with Google.)</Description>
     <Authors>Brandon Potter</Authors>
     <Company>Brandon Potter</Company>
-    <Version>3.0.0-beta1</Version>
+    <Version>3.0.0-beta2</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/BrandonPotter/GoogleAuthenticator</PackageProjectUrl>
     <PackageId>GoogleAuthenticator</PackageId>

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -60,12 +60,7 @@ namespace Google.Authenticator
                 throw new NullReferenceException("Account Title is null");
             }
 
-            // MS wants us to change this to use EscapeDataString - https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0013
-            // But that changes the output. Specifically "a@b.com" becomes "a%40b.com"
-            // See issue https://github.com/BrandonPotter/GoogleAuthenticator/issues/103
-            #pragma warning disable SYSLIB0013
-            accountTitleNoSpaces = RemoveWhitespace(Uri.EscapeUriString(accountTitleNoSpaces));
-            #pragma warning restore SYSLIB0013
+            accountTitleNoSpaces = RemoveWhitespace(Uri.EscapeDataString(accountTitleNoSpaces));
 
             var encodedSecretKey = Base32Encoding.ToString(accountSecretKey);
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ bool result = tfa.ValidateTwoFactorPIN(key, txtCode.Text)
 
 ## Updates
 
-### 3.0.0-beta
+### 3.0.0-beta2
+Changed from using `EscapeUriString` to `EscapeDataString` to encode the "account title" as the former is [obsolete in .Net 6](https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0013). This changes the value in the generated data string from `a@b.com` to `a%40b.com`. We have tested this with Google Authenticator, Lastpass Authenticator and Microsoft Authenticator. All three of them handle it correctl and all three recognise that it is still the same account so this should be safe in most cases.
+
+### 3.0.0-beta1
 - Removed support for legacy .Net Framework. Lowest supported versions are now netstandard2.0 and .Net 4.6.2.  
 - All use of System.Drawing has been removed. In 2.5, only Net 6.0 avoided System.Drawing.
 - Linux installations no longer need to ensure `libgdiplus` is installed as it is no longer used.


### PR DESCRIPTION
Fixes #103 

I've tested this with three different authenticators and they all handle it correctly:
- They still display the issuer name correctly
- It recognises that an account added with the old version is the same if I try to add it again with the new version