### PR TITLE
Removed Net5 and added Net7

### DIFF
--- a/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
+++ b/Google.Authenticator.Tests/Google.Authenticator.Tests.csproj
@@ -4,9 +4,9 @@
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX> 
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux> 
-    <TargetFrameworks Condition="'$(IsWindows)'=='true'">net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsLinux)'=='true'">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsOSX)'=='true'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'=='true'">net462;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsLinux)'=='true'">netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsOSX)'=='true'">netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Removed .Net 5 from the test frameworks and added .Net 7.

.Net 5 is no longer supported and is not installed on the build machines.

Netcoreapp 3.1 is still in there.