### PR TITLE
Support ValidateTwoFactorPIN with iterationOffset as parameter

### DIFF
--- a/Google.Authenticator.Tests/ValidationTests.cs
+++ b/Google.Authenticator.Tests/ValidationTests.cs
@@ -28,6 +28,9 @@ namespace Google.Authenticator.Tests
             subject.ValidateTwoFactorPIN(secretAsBytes, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved));
             subject.ValidateTwoFactorPIN(secretAsBase32, pin, true);
             subject.ValidateTwoFactorPIN(secretAsBase32, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved), true);
+            subject.ValidateTwoFactorPIN(secret, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2, false);
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2, true);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2);
         }
 
         public static IEnumerable<object[]> GetPins()

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -331,7 +331,7 @@ namespace Google.Authenticator
             return codes.ToArray();
         }
 
-        public static byte[] ConvertSecretToBytes(string secret, bool secretIsBase32) =>
+        private static byte[] ConvertSecretToBytes(string secret, bool secretIsBase32) =>
             secretIsBase32 ? Base32Encoding.ToBytes(secret) : Encoding.UTF8.GetBytes(secret);
     }
 }


### PR DESCRIPTION
I need to allow code with ``iterationOffset`` == 1. But with the current implementation, it's non-obvious how to do this.

If set ``timeTolerance`` to 30 seconds, I get ``iterationOffset`` 0.
If set ``timeTolerance`` to 60 seconds, I get ``iterationOffset`` 2.
To obtain ``iterationOffset`` == 1, I need to set the time between 30 and 60 seconds. It's strange.

```C#
if (timeTolerance.TotalSeconds > 30)
    iterationOffset = Convert.ToInt32(timeTolerance.TotalSeconds / 30.00)
```

I don't want to break compatibility, so let's just allow the user to specify ``iterationOffset``.
