### PR TITLE
Fixed problem with 30 second interval

### DIFF
--- a/Google.Authenticator.Tests/ValidationTests.cs
+++ b/Google.Authenticator.Tests/ValidationTests.cs
@@ -33,6 +33,32 @@ namespace Google.Authenticator.Tests
             subject.ValidateTwoFactorPIN(secretAsBytes, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2);
         }
 
+        [Fact]
+        public void GetCurrentPinsHandles15SecondInterval()
+        {
+            // This is nonsensical, really, as anything less than 30 == 0 in practice.
+            var subject = new TwoFactorAuthenticator();
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(15)).Length.ShouldBe(1);
+        }
+
+
+        [Fact]
+        public void GetCurrentPinsHandles30SecondInterval()
+        {
+            var subject = new TwoFactorAuthenticator();
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(30)).Length.ShouldBe(3);
+        }
+
+        [Fact]
+        public void GetCurrentPinsHandles60SecondInterval()
+        {
+            var subject = new TwoFactorAuthenticator();
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(60)).Length.ShouldBe(5);
+        }
+
         public static IEnumerable<object[]> GetPins()
         {
             var subject = new TwoFactorAuthenticator();

--- a/Google.Authenticator/Google.Authenticator.csproj
+++ b/Google.Authenticator/Google.Authenticator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Product>Google Authenticator Two-Factor</Product>
@@ -6,7 +6,7 @@
     <Description>Google Authenticator Two-Factor Authentication Library (Not officially affiliated with Google.)</Description>
     <Authors>Brandon Potter</Authors>
     <Company>Brandon Potter</Company>
-    <Version>3.1.0</Version>
+    <Version>3.1.1-beta1</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/BrandonPotter/GoogleAuthenticator</PackageProjectUrl>
     <PackageId>GoogleAuthenticator</PackageId>

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -303,7 +303,7 @@ namespace Google.Authenticator
         {
             var iterationOffset = 0;
 
-            if (timeTolerance.TotalSeconds > 30)
+            if (timeTolerance.TotalSeconds >= 30)
                 iterationOffset = Convert.ToInt32(timeTolerance.TotalSeconds / 30.00);
 
             return GetCurrentPINs(accountSecretKey, iterationOffset);

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ bool result = tfa.ValidateTwoFactorPIN(key, txtCode.Text)
 
 ## Update history
 
+### 3.1.1-beta1
+Fixed an edge case where specifying an interval of 30 seconds to the Validate function would be treated as if you had passed in 0.
+
+### 3.1.0
+
 ### 3.0.0
 
 - Removed support for legacy .Net Framework. Lowest supported versions are now netstandard2.0 and .Net 4.6.2.  


### PR DESCRIPTION
Specifying a 30 second interval to the Validate function would be treated the same as specifying 0. 

Fixes #160 