### PR TITLE
Added support for HMACSHA 256 and 512

### DIFF
--- a/Google.Authenticator.Tests/AuthCodeTest.cs
+++ b/Google.Authenticator.Tests/AuthCodeTest.cs
@@ -24,12 +24,80 @@ namespace Google.Authenticator.Tests
         }
         
         [Fact]
+        public void BasicAuthCodeTestSHA256()
+        {
+            var secretKey = "PJWUMZKAUUFQKJBAMD6VGJ6RULFVW4ZH";
+            var expected = "002939";
+
+            var tfa = new TwoFactorAuthenticator(HashType.SHA256);
+
+            var currentTime = 1416643820;
+
+            // I actually think you are supposed to divide the time by 30 seconds?
+            // Maybe need an overload that takes a DateTime?
+            var actual = tfa.GeneratePINAtInterval(secretKey, currentTime, 6);
+
+            actual.ShouldBe(expected);
+        }
+        
+        [Fact]
+        public void BasicAuthCodeTestSHA512()
+        {
+            var secretKey = "PJWUMZKAUUFQKJBAMD6VGJ6RULFVW4ZH";
+            var expected = "461461";
+
+            var tfa = new TwoFactorAuthenticator(HashType.SHA512);
+
+            var currentTime = 1416643820;
+
+            // I actually think you are supposed to divide the time by 30 seconds?
+            // Maybe need an overload that takes a DateTime?
+            var actual = tfa.GeneratePINAtInterval(secretKey, currentTime, 6);
+
+            actual.ShouldBe(expected);
+        }
+        
+        [Fact]
         public void Base32AuthCodeTest()
         {
             var secretKey = Base32Encoding.ToString(Encoding.UTF8.GetBytes("PJWUMZKAUUFQKJBAMD6VGJ6RULFVW4ZH"));
             var expected = "551508";
 
             var tfa = new TwoFactorAuthenticator();
+
+            var currentTime = 1416643820;
+
+            // I actually think you are supposed to divide the time by 30 seconds?
+            // Maybe need an overload that takes a DateTime?
+            var actual = tfa.GeneratePINAtInterval(secretKey, currentTime, 6, true);
+
+            actual.ShouldBe(expected);
+        }
+        
+        [Fact]
+        public void Base32AuthCodeTestSHA256()
+        {
+            var secretKey = Base32Encoding.ToString(Encoding.UTF8.GetBytes("PJWUMZKAUUFQKJBAMD6VGJ6RULFVW4ZH"));
+            var expected = "002939";
+
+            var tfa = new TwoFactorAuthenticator(HashType.SHA256);
+
+            var currentTime = 1416643820;
+
+            // I actually think you are supposed to divide the time by 30 seconds?
+            // Maybe need an overload that takes a DateTime?
+            var actual = tfa.GeneratePINAtInterval(secretKey, currentTime, 6, true);
+
+            actual.ShouldBe(expected);
+        }
+        
+        [Fact]
+        public void Base32AuthCodeTestSHA512()
+        {
+            var secretKey = Base32Encoding.ToString(Encoding.UTF8.GetBytes("PJWUMZKAUUFQKJBAMD6VGJ6RULFVW4ZH"));
+            var expected = "461461";
+
+            var tfa = new TwoFactorAuthenticator(HashType.SHA512);
 
             var currentTime = 1416643820;
 

--- a/Google.Authenticator.Tests/GeneratePinTests.cs
+++ b/Google.Authenticator.Tests/GeneratePinTests.cs
@@ -26,6 +26,44 @@ namespace Google.Authenticator.Tests
             pinFromBytes.ShouldBe(expected);
             pinFromBase32.ShouldBe(expected);
         }
+        [Fact]
+        public void OverloadsReturnSamePINSHA256()
+        {
+            var secret = "JBSWY3DPEHPK3PXP";
+            var secretAsBytes = Encoding.UTF8.GetBytes(secret);
+            var secretAsBase32 = Base32Encoding.ToString(secretAsBytes);
+            long counter = 54615912;
+            var expected = "087141";
+
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+
+            var pinFromString = subject.GeneratePINAtInterval(secret, counter);
+            var pinFromBytes = subject.GeneratePINAtInterval(secretAsBytes, counter);
+            var pinFromBase32 = subject.GeneratePINAtInterval(secretAsBase32, counter, secretIsBase32: true);
+
+            pinFromString.ShouldBe(expected);
+            pinFromBytes.ShouldBe(expected);
+            pinFromBase32.ShouldBe(expected);
+        }
+        [Fact]
+        public void OverloadsReturnSamePINSHA512()
+        {
+            var secret = "JBSWY3DPEHPK3PXP";
+            var secretAsBytes = Encoding.UTF8.GetBytes(secret);
+            var secretAsBase32 = Base32Encoding.ToString(secretAsBytes);
+            long counter = 54615912;
+            var expected = "397230";
+
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
+
+            var pinFromString = subject.GeneratePINAtInterval(secret, counter);
+            var pinFromBytes = subject.GeneratePINAtInterval(secretAsBytes, counter);
+            var pinFromBase32 = subject.GeneratePINAtInterval(secretAsBase32, counter, secretIsBase32: true);
+
+            pinFromString.ShouldBe(expected);
+            pinFromBytes.ShouldBe(expected);
+            pinFromBase32.ShouldBe(expected);
+        }
     }
 }
 

--- a/Google.Authenticator.Tests/QRCodeTest.cs
+++ b/Google.Authenticator.Tests/QRCodeTest.cs
@@ -11,9 +11,9 @@ namespace Google.Authenticator.Tests
     public class QRCodeTest
     {
         [Theory]
-        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer&algorithm=SHA1")]
-        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar&algorithm=SHA1")]
-        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA&algorithm=SHA1")]
+        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer")]
+        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar")]
+        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA")]
         public void CanGenerateQRCode(string issuer, string expectedUrl)
         {
             var subject = new TwoFactorAuthenticator();

--- a/Google.Authenticator.Tests/QRCodeTest.cs
+++ b/Google.Authenticator.Tests/QRCodeTest.cs
@@ -11,9 +11,9 @@ namespace Google.Authenticator.Tests
     public class QRCodeTest
     {
         [Theory]
-        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer")]
-        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar")]
-        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA")]
+        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer&algorithm=SHA1")]
+        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar&algorithm=SHA1")]
+        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA&algorithm=SHA1")]
         public void CanGenerateQRCode(string issuer, string expectedUrl)
         {
             var subject = new TwoFactorAuthenticator();

--- a/Google.Authenticator.Tests/QRCodeTest.cs
+++ b/Google.Authenticator.Tests/QRCodeTest.cs
@@ -29,6 +29,44 @@ namespace Google.Authenticator.Tests
             actualUrl.ShouldBe(expectedUrl);
         }
 
+        [Theory]
+        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer&algorithm=SHA256")]
+        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar&algorithm=SHA256")]
+        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA&algorithm=SHA256")]
+        public void CanGenerateSHA256QRCode(string issuer, string expectedUrl)
+        {
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+            var setupCodeInfo = subject.GenerateSetupCode(
+                issuer,
+                "a@b.com",
+                "secret", 
+                false, 
+                2);
+
+            var actualUrl = ExtractUrlFromQRImage(setupCodeInfo.QrCodeSetupImageUrl);
+
+            actualUrl.ShouldBe(expectedUrl);
+        }
+
+        [Theory]
+        [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer&algorithm=SHA512")]
+        [InlineData("Foo & Bar", "otpauth://totp/Foo%20%26%20Bar:a%40b.com?secret=ONSWG4TFOQ&issuer=Foo%20%26%20Bar&algorithm=SHA512")]
+        [InlineData("个", "otpauth://totp/%E4%B8%AA:a%40b.com?secret=ONSWG4TFOQ&issuer=%E4%B8%AA&algorithm=SHA512")]
+        public void CanGenerateSHA512QRCode(string issuer, string expectedUrl)
+        {
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
+            var setupCodeInfo = subject.GenerateSetupCode(
+                issuer,
+                "a@b.com",
+                "secret", 
+                false, 
+                2);
+
+            var actualUrl = ExtractUrlFromQRImage(setupCodeInfo.QrCodeSetupImageUrl);
+
+            actualUrl.ShouldBe(expectedUrl);
+        }
+
         private static string ExtractUrlFromQRImage(string qrCodeSetupImageUrl)
         {
             var headerLength = "data:image/png;base64,".Length;

--- a/Google.Authenticator.Tests/SetupCodeTests.cs
+++ b/Google.Authenticator.Tests/SetupCodeTests.cs
@@ -26,5 +26,47 @@ namespace Google.Authenticator.Tests
             setupCodeFromByteArray.ManualEntryKey.ShouldBe(expected);
             setupCodeFromBase32.ManualEntryKey.ShouldBe(expected);
         }
+
+        [Fact]
+        public void ByteAndStringGeneratesSameSetupCodeSHA256()
+        {
+            var secret = "12345678901234567890123456789012";
+            var secretAsByteArray = Encoding.UTF8.GetBytes(secret);
+            var secretAsBase32 = Base32Encoding.ToString(secretAsByteArray);
+            var issuer = "Test";
+            var accountName = "TestAccount";
+            var expected = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA";
+
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+
+            var setupCodeFromString = subject.GenerateSetupCode(issuer, accountName, secret, false);
+            var setupCodeFromByteArray = subject.GenerateSetupCode(issuer, accountName, secretAsByteArray, 3, false);
+            var setupCodeFromBase32 = subject.GenerateSetupCode(issuer, accountName, secretAsBase32, true);
+
+            setupCodeFromString.ManualEntryKey.ShouldBe(expected);
+            setupCodeFromByteArray.ManualEntryKey.ShouldBe(expected);
+            setupCodeFromBase32.ManualEntryKey.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void ByteAndStringGeneratesSameSetupCodeSHA512()
+        {
+            var secret = "12345678901234567890123456789012";
+            var secretAsByteArray = Encoding.UTF8.GetBytes(secret);
+            var secretAsBase32 = Base32Encoding.ToString(secretAsByteArray);
+            var issuer = "Test";
+            var accountName = "TestAccount";
+            var expected = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA";
+
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
+
+            var setupCodeFromString = subject.GenerateSetupCode(issuer, accountName, secret, false);
+            var setupCodeFromByteArray = subject.GenerateSetupCode(issuer, accountName, secretAsByteArray, 3, false);
+            var setupCodeFromBase32 = subject.GenerateSetupCode(issuer, accountName, secretAsBase32, true);
+
+            setupCodeFromString.ManualEntryKey.ShouldBe(expected);
+            setupCodeFromByteArray.ManualEntryKey.ShouldBe(expected);
+            setupCodeFromBase32.ManualEntryKey.ShouldBe(expected);
+        }
     }
 }

--- a/Google.Authenticator.Tests/ValidationTests.cs
+++ b/Google.Authenticator.Tests/ValidationTests.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using Shouldly;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System;
@@ -33,6 +32,46 @@ namespace Google.Authenticator.Tests
             subject.ValidateTwoFactorPIN(secretAsBytes, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2);
         }
 
+        [Theory]
+        [MemberData(nameof(GetPins), HashType.SHA256)]
+        public void ValidateWorksWithDifferentSecretTypesSHA256(string pin, int irrelevantNumberToAvoidDuplicatePinsBeingRemoved)
+        {
+            // We can't directly test that the different overloads for GetCurrentPIN creates the same result,
+            // as the time difference may may cause different PINS to be created.
+            // So instead we generate the PINs by each method and validate each one by each method.
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+
+            subject.ValidateTwoFactorPIN(secret, pin, false);
+            subject.ValidateTwoFactorPIN(secret, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved), false);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved));
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, true);
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved), true);
+            subject.ValidateTwoFactorPIN(secret, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2, false);
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2, true);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPins), HashType.SHA512)]
+        public void ValidateWorksWithDifferentSecretTypesSHA512(string pin, int irrelevantNumberToAvoidDuplicatePinsBeingRemoved)
+        {
+            // We can't directly test that the different overloads for GetCurrentPIN creates the same result,
+            // as the time difference may may cause different PINS to be created.
+            // So instead we generate the PINs by each method and validate each one by each method.
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
+
+            subject.ValidateTwoFactorPIN(secret, pin, false);
+            subject.ValidateTwoFactorPIN(secret, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved), false);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved));
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, true);
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, TimeSpan.FromMinutes(irrelevantNumberToAvoidDuplicatePinsBeingRemoved), true);
+            subject.ValidateTwoFactorPIN(secret, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2, false);
+            subject.ValidateTwoFactorPIN(secretAsBase32, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2, true);
+            subject.ValidateTwoFactorPIN(secretAsBytes, pin, irrelevantNumberToAvoidDuplicatePinsBeingRemoved * 2);
+        }
+
         [Fact]
         public void GetCurrentPinsHandles15SecondInterval()
         {
@@ -42,11 +81,44 @@ namespace Google.Authenticator.Tests
             subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(15)).Length.ShouldBe(1);
         }
 
+        [Fact]
+        public void GetCurrentPinsHandles15SecondIntervalSHA256()
+        {
+            // This is nonsensical, really, as anything less than 30 == 0 in practice.
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(15)).Length.ShouldBe(1);
+        }
+
+        [Fact]
+        public void GetCurrentPinsHandles15SecondIntervalSHA512()
+        {
+            // This is nonsensical, really, as anything less than 30 == 0 in practice.
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(15)).Length.ShouldBe(1);
+        }
 
         [Fact]
         public void GetCurrentPinsHandles30SecondInterval()
         {
             var subject = new TwoFactorAuthenticator();
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(30)).Length.ShouldBe(3);
+        }
+
+        [Fact]
+        public void GetCurrentPinsHandles30SecondIntervalSHA256()
+        {
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(30)).Length.ShouldBe(3);
+        }
+
+        [Fact]
+        public void GetCurrentPinsHandles30SecondIntervalSHA512()
+        {
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
 
             subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(30)).Length.ShouldBe(3);
         }
@@ -59,9 +131,37 @@ namespace Google.Authenticator.Tests
             subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(60)).Length.ShouldBe(5);
         }
 
+        [Fact]
+        public void GetCurrentPinsHandles60SecondIntervalSHA256()
+        {
+            var subject = new TwoFactorAuthenticator(HashType.SHA256);
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(60)).Length.ShouldBe(5);
+        }
+
+        [Fact]
+        public void GetCurrentPinsHandles60SecondIntervalSHA512()
+        {
+            var subject = new TwoFactorAuthenticator(HashType.SHA512);
+
+            subject.GetCurrentPINs(secret, TimeSpan.FromSeconds(60)).Length.ShouldBe(5);
+        }
+
         public static IEnumerable<object[]> GetPins()
         {
             var subject = new TwoFactorAuthenticator();
+
+            yield return new object[] { subject.GetCurrentPIN(secret), 2 };
+            yield return new object[] { subject.GetCurrentPIN(secret, DateTime.UtcNow), 3 };
+            yield return new object[] { subject.GetCurrentPIN(secretAsBytes), 4 };
+            yield return new object[] { subject.GetCurrentPIN(secretAsBytes, DateTime.UtcNow), 5 };
+            yield return new object[] { subject.GetCurrentPIN(secretAsBase32, true), 6 };
+            yield return new object[] { subject.GetCurrentPIN(secretAsBase32, DateTime.UtcNow, true), 7 };
+        }
+
+        public static IEnumerable<object[]> GetPins(HashType hashType)
+        {
+            var subject = new TwoFactorAuthenticator(hashType);
 
             yield return new object[] { subject.GetCurrentPIN(secret), 2 };
             yield return new object[] { subject.GetCurrentPIN(secret, DateTime.UtcNow), 3 };

--- a/Google.Authenticator.WinTest/Form1.cs
+++ b/Google.Authenticator.WinTest/Form1.cs
@@ -49,7 +49,7 @@ namespace Google.Authenticator.WinTest
 
         private void btnGetCurrentCode_Click(object sender, EventArgs e)
         {
-            this.txtCurrentCodes.Text = string.Join(System.Environment.NewLine, new TwoFactorAuthenticator().GetCurrentPINs(this.txtSecretKey.Text));
+            this.txtCurrentCodes.Text = string.Join(Environment.NewLine, new TwoFactorAuthenticator(HashType.SHA256).GetCurrentPINs(this.txtSecretKey.Text));
         }
 
         private void btnDebugTest_Click(object sender, EventArgs e)

--- a/Google.Authenticator.WinTest/Form1.cs
+++ b/Google.Authenticator.WinTest/Form1.cs
@@ -27,7 +27,7 @@ namespace Google.Authenticator.WinTest
 
         private void btnSetup_Click(object sender, EventArgs e)
         {
-            TwoFactorAuthenticator tfA = new TwoFactorAuthenticator();
+            TwoFactorAuthenticator tfA = new TwoFactorAuthenticator(HashType.SHA256);
             var setupCode = tfA.GenerateSetupCode(this.txtAccountTitle.Text, this.txtAccountTitle.Text, this.txtSecretKey.Text, false, 3);
 
             //WebClient wc = new WebClient();
@@ -41,7 +41,7 @@ namespace Google.Authenticator.WinTest
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            TwoFactorAuthenticator tfA = new TwoFactorAuthenticator();
+            TwoFactorAuthenticator tfA = new TwoFactorAuthenticator(HashType.SHA256);
             var result = tfA.ValidateTwoFactorPIN(txtSecretKey.Text, this.txtCode.Text);
 
             MessageBox.Show(result ? "Validated!" : "Incorrect", "Result");

--- a/Google.Authenticator/HashType.cs
+++ b/Google.Authenticator/HashType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Authenticator
+{
+    public enum HashType
+    {
+        SHA1,
+        SHA256,
+        SHA512
+    }
+}

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -21,7 +21,13 @@ namespace Google.Authenticator
 
         private TimeSpan DefaultClockDriftTolerance { get; set; }
 
-        public TwoFactorAuthenticator() => DefaultClockDriftTolerance = TimeSpan.FromMinutes(5);
+        private HashType HashType { get; set; }
+
+        public TwoFactorAuthenticator(HashType hashType = HashType.SHA1)
+        {
+            HashType = hashType;
+            DefaultClockDriftTolerance = TimeSpan.FromMinutes(5);
+        }
 
         /// <summary>
         /// Generate a setup code for a Google Authenticator user to scan
@@ -65,11 +71,11 @@ namespace Google.Authenticator
             var encodedSecretKey = Base32Encoding.ToString(accountSecretKey);
 
             var provisionUrl = string.IsNullOrWhiteSpace(issuer)
-                ? $"otpauth://totp/{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}"
+                ? $"otpauth://totp/{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}&algorithm={HashType}"
                 //  https://github.com/google/google-authenticator/wiki/Conflicting-Accounts
                 // Added additional prefix to account otpauth://totp/Company:joe_example@gmail.com
                 // for backwards compatibility
-                : $"otpauth://totp/{UrlEncode(issuer)}:{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}&issuer={UrlEncode(issuer)}";
+                : $"otpauth://totp/{UrlEncode(issuer)}:{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}&issuer={UrlEncode(issuer)}&algorithm={HashType}";
 
             return new SetupCode(
                 accountTitleNoSpaces,
@@ -145,7 +151,14 @@ namespace Google.Authenticator
             if (BitConverter.IsLittleEndian)
                 Array.Reverse(counter);
 
-            var hmac = new HMACSHA1(key);
+            HMAC hmac;
+            if (HashType == HashType.SHA256)
+                hmac = new HMACSHA256(key);
+            else if (HashType == HashType.SHA512)
+                hmac = new HMACSHA512(key);
+            else
+                hmac = new HMACSHA1(key);
+
             var hash = hmac.ComputeHash(counter);
             var offset = hash[hash.Length - 1] & 0xf;
 

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -23,7 +23,11 @@ namespace Google.Authenticator
 
         private HashType HashType { get; set; }
 
-        public TwoFactorAuthenticator(HashType hashType = HashType.SHA1)
+         public TwoFactorAuthenticator() : this(HashType.SHA1)
+        {}
+        
+        public TwoFactorAuthenticator(HashType hashType)
+
         {
             HashType = hashType;
             DefaultClockDriftTolerance = TimeSpan.FromMinutes(5);

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -71,11 +71,11 @@ namespace Google.Authenticator
             var encodedSecretKey = Base32Encoding.ToString(accountSecretKey);
 
             var provisionUrl = string.IsNullOrWhiteSpace(issuer)
-                ? $"otpauth://totp/{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}&algorithm={HashType}"
+                ? $"otpauth://totp/{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}{(HashType == HashType.SHA1 ? "" : $"&algorithm={HashType}")}"
                 //  https://github.com/google/google-authenticator/wiki/Conflicting-Accounts
                 // Added additional prefix to account otpauth://totp/Company:joe_example@gmail.com
                 // for backwards compatibility
-                : $"otpauth://totp/{UrlEncode(issuer)}:{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}&issuer={UrlEncode(issuer)}&algorithm={HashType}";
+                : $"otpauth://totp/{UrlEncode(issuer)}:{accountTitleNoSpaces}?secret={encodedSecretKey.Trim('=')}&issuer={UrlEncode(issuer)}{(HashType == HashType.SHA1 ? "" : $"&algorithm={HashType}")}";
 
             return new SetupCode(
                 accountTitleNoSpaces,


### PR DESCRIPTION
Adds support for specifying the algorithm (SHA1, SHA256, or SHA512) per the [RFC](https://datatracker.ietf.org/doc/html/rfc6238#section-1.2)

TODO: update tests to check all three algorithms

Is this technically a breaking change because if the server is configured for SHA256 or SHA512 but the existing clients are using SHA1 they won't be able to authenticate? I kinda think that's the responsibility of the server.

Resolves #197 

/cc @flytzen @BrandonPotter 