### PR TITLE
Update mac tests

### DIFF
--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -22,6 +22,11 @@ jobs:
   
   steps:
 
+  - task: UseDotNet@2
+    displauName: Install .NET 6
+    inputs:
+      version: 6.0.x
+  
   # There is a legacy project in the solution that dotnet won't build, so restoring and building individual projects
   - script: dotnet restore ./Google.Authenticator/Google.Authenticator.csproj 
     displayName: dotnet restore package


### PR DESCRIPTION
Mac doesn't contain .NET 6 by default now