### PR TITLE
Add SetupUrl to the SetupCode class

### DIFF
--- a/Google.Authenticator.Tests/QRCodeAndSetupUrlTests.cs
+++ b/Google.Authenticator.Tests/QRCodeAndSetupUrlTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 
 namespace Google.Authenticator.Tests
 {
-    public class QRCodeTest
+    public class QRCodeAndSetupUrlTests
     {
         [Theory]
         [InlineData("issuer", "otpauth://totp/issuer:a%40b.com?secret=ONSWG4TFOQ&issuer=issuer")]
@@ -25,8 +25,13 @@ namespace Google.Authenticator.Tests
                 2);
 
             var actualUrl = ExtractUrlFromQRImage(setupCodeInfo.QrCodeSetupImageUrl);
+            var rawUrl = setupCodeInfo.SetupUrl;
 
-            actualUrl.ShouldBe(expectedUrl);
+            Assert.Multiple(() =>
+            {
+                actualUrl.ShouldBe(expectedUrl, "QR Code Url is not as expected");
+                rawUrl.ShouldBe(expectedUrl, "SetupUrl is not as expected");
+            });
         }
 
         [Theory]
@@ -44,8 +49,13 @@ namespace Google.Authenticator.Tests
                 2);
 
             var actualUrl = ExtractUrlFromQRImage(setupCodeInfo.QrCodeSetupImageUrl);
+            var rawUrl = setupCodeInfo.SetupUrl;
 
-            actualUrl.ShouldBe(expectedUrl);
+            Assert.Multiple(() =>
+            {
+                actualUrl.ShouldBe(expectedUrl, "QR Code Url is not as expected");
+                rawUrl.ShouldBe(expectedUrl, "SetupUrl is not as expected");
+            });
         }
 
         [Theory]
@@ -63,8 +73,13 @@ namespace Google.Authenticator.Tests
                 2);
 
             var actualUrl = ExtractUrlFromQRImage(setupCodeInfo.QrCodeSetupImageUrl);
+            var rawUrl = setupCodeInfo.SetupUrl;
 
-            actualUrl.ShouldBe(expectedUrl);
+            Assert.Multiple(() =>
+            {
+                actualUrl.ShouldBe(expectedUrl, "QR Code Url is not as expected");
+                rawUrl.ShouldBe(expectedUrl, "SetupUrl is not as expected");
+            });
         }
 
         private static string ExtractUrlFromQRImage(string qrCodeSetupImageUrl)

--- a/Google.Authenticator/SetupCode.cs
+++ b/Google.Authenticator/SetupCode.cs
@@ -9,13 +9,19 @@
         /// </summary>
         public string QrCodeSetupImageUrl { get; internal set; }
 
+        /// <summary>
+        /// The Raw otp:// url
+        /// </summary>
+        public string SetupUrl { get; internal set; }
+
         public SetupCode() { }
 
-        public SetupCode(string account, string manualEntryKey, string qrCodeSetupImageUrl)
+        public SetupCode(string account, string manualEntryKey, string qrCodeSetupImageUrl, string setupUrl)
         {
             Account = account;
             ManualEntryKey = manualEntryKey;
             QrCodeSetupImageUrl = qrCodeSetupImageUrl;
+            SetupUrl = setupUrl;
         }
     }
 }

--- a/Google.Authenticator/TwoFactorAuthenticator.cs
+++ b/Google.Authenticator/TwoFactorAuthenticator.cs
@@ -98,7 +98,8 @@ namespace Google.Authenticator
             return new SetupCode(
                 accountTitleNoSpaces,
                 encodedSecretKey.Trim('='),
-                generateQrCode ? GenerateQrCodeUrl(qrPixelsPerModule, provisionUrl) : "");
+                generateQrCode ? GenerateQrCodeUrl(qrPixelsPerModule, provisionUrl) : "",
+                provisionUrl);
         }
 
         private static string GenerateQrCodeUrl(int qrPixelsPerModule, string provisionUrl)

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -35,6 +35,13 @@ jobs:
   - script: dotnet build ./Google.Authenticator.Tests/Google.Authenticator.Tests.csproj --configuration $(buildConfiguration) --no-restore --no-dependencies
     displayName: build tests
 
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK
+    inputs:
+      packageType: sdk
+      version: 6.x
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+
   - task: DotNetCoreCLI@2
     displayName: test
     inputs:

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -39,7 +39,7 @@ jobs:
     displayName: Use .NET Core SDK
     inputs:
       packageType: sdk
-      version: 6.x
+      version: 7.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - task: DotNetCoreCLI@2

--- a/build/azure-pipeline.yaml
+++ b/build/azure-pipeline.yaml
@@ -36,11 +36,16 @@ jobs:
     displayName: build tests
 
   - task: UseDotNet@2
-    displayName: Use .NET Core SDK
+    displayName: Install dotnet 6
+    inputs:
+      packageType: sdk
+      version: 6.x
+
+  - task: UseDotNet@2
+    displayName: Install dotnet 7
     inputs:
       packageType: sdk
       version: 7.x
-      installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - task: DotNetCoreCLI@2
     displayName: test


### PR DESCRIPTION
Related to #253, this change adds a new property to the `SetupCode` class: `SetupUrl` - This url contains the raw `otpauth://` url for the setup.

This value is identical to the url encoded within the QR Code, and can be used to provide a clickable link to set up, for users who are attempting to set up the authenticator on the device they are viewing the page.